### PR TITLE
Basic auth is not allowed on endpoints that aren't the token endpoint

### DIFF
--- a/examples/cc/server.js
+++ b/examples/cc/server.js
@@ -21,7 +21,8 @@ var RESOURCES = Object.freeze({
     INITIAL: "/",
     TOKEN: "/token",
     PUBLIC: "/public",
-    SECRET: "/secret"
+    SECRET: "/secret",
+    BASICAUTH: "/basicauth"
 });
 
 server.use(restify.authorizationParser());
@@ -76,6 +77,45 @@ server.get(RESOURCES.SECRET, function (req, res) {
 
     res.contentType = "application/hal+json";
     res.send(response);
+});
+
+/*
+    This is an endpoint that requires a valid client through
+    basic auth OR a valid oauth token (such as a resource
+    availible to a client or a verified user)
+ */
+server.get(RESOURCES.BASICAUTH, function (req, res) {
+    
+    var response;
+
+    if (!req.username) {
+
+        if (req.authorization.scheme === "Basic") {
+
+            hooks.grantClientToken(req.authorization.basic.username, req.authorization.basic.password, function (err, valid) {
+                if (valid) {
+                    response = {
+                        "message" : "valid client basic auth"
+                    };
+                } else {
+                    return res.sendUnauthorized();
+                }
+            });
+            
+        } else {
+            return res.sendUnauthorized();
+        }
+
+
+    } else {
+        response = {
+            "message": "valid oauth token"
+        };
+    }
+
+    res.contentType = "application/hal+json";
+    res.send(response);
+
 });
 
 server.listen(8080);

--- a/lib/common/makeSetup.js
+++ b/lib/common/makeSetup.js
@@ -40,7 +40,7 @@ module.exports = function makeSetup(grantTypes, reqPropertyName, requiredHooks, 
             if (req.method === "POST" && req.path() === options.tokenEndpoint) {
                 // This is handled by the route installed above, so do nothing.
                 next();
-            } else if (req.authorization.scheme) {
+            } else if (req.authorization.scheme && req.authorization.scheme !== "Basic") {
                 handleAuthenticatedResource(req, res, next, options);
             } else {
                 req.username = null;

--- a/test/cc-integration.coffee
+++ b/test/cc-integration.coffee
@@ -30,6 +30,30 @@ suite
             res.headers.should.have.property("link").that.equals(expectedLink)
         )
     .next()
+    .path("/basicauth")
+        .discuss("with no basic auth or token")
+        .get()
+            .expect(401)
+            .expect("should respond with WWW-Authenticate and Link headers", (err, res, body) ->
+                expectedLink = '</token>; rel="oauth2-token"; grant-types="client_credentials"; token-types="bearer"'
+
+                res.headers.should.have.property("www-authenticate").that.equals('Bearer realm="Who goes there?"')
+                res.headers.should.have.property("link").that.equals(expectedLink)
+            )
+        .undiscuss()
+        .discuss("with valid client basic auth")
+            .setHeader("Authorization", "Basic #{basicAuth}")
+            .setHeader("Content-Type", "application/json")
+            .get()
+                .expect(200)
+                .expect("should respond successfully", (err, res, body) =>
+                    result = JSON.parse(body)
+
+                    result.should.have.property("message", "valid client basic auth")
+                )
+        .undiscuss()
+    .unpath()
+    .next()
     .get("/")
         .expect(
             200,
@@ -80,6 +104,14 @@ suite
         )
     .get("/secret")
         .expect(200)
+    .next()
+    .get("/basicauth")
+        .expect(200)
+        .expect("should respond successfully", (err, res, body) =>
+            result = JSON.parse(body)
+
+            result.should.have.property("message", "valid oauth token")
+        )
     .next()
     .get("/public")
         .expect(200)

--- a/test/ropc-integration.coffee
+++ b/test/ropc-integration.coffee
@@ -31,6 +31,30 @@ suite
             res.headers.should.have.property("link").that.equals(expectedLink)
         )
     .next()
+    .path("/basicauth")
+        .discuss("with no basic auth or token")
+        .get()
+            .expect(401)
+            .expect("should respond with WWW-Authenticate and Link headers", (err, res, body) ->
+                expectedLink = '</token>; rel="oauth2-token"; grant-types="password"; token-types="bearer"'
+
+                res.headers.should.have.property("www-authenticate").that.equals('Bearer realm="Who goes there?"')
+                res.headers.should.have.property("link").that.equals(expectedLink)
+            )
+        .undiscuss()
+        .discuss("with valid client basic auth")
+            .setHeader("Authorization", "Basic #{basicAuth}")
+            .setHeader("Content-Type", "application/json")
+            .get()
+                .expect(200)
+                .expect("should respond successfully", (err, res, body) =>
+                    result = JSON.parse(body)
+
+                    result.should.have.property("message", "valid client basic auth")
+                )
+        .undiscuss()
+    .unpath()
+    .next()
     .get("/")
         .expect(
             200,
@@ -90,6 +114,14 @@ suite
         )
     .get("/secret")
         .expect(200)
+    .next()
+    .get("/basicauth")
+        .expect(200)
+        .expect("should respond successfully", (err, res, body) =>
+            result = JSON.parse(body)
+
+            result.should.have.property("message", "valid oauth token")
+        )
     .next()
     .get("/public")
         .expect(200)


### PR DESCRIPTION
Right now, if I'm using restify-oauth2 then I can't have basic auth on any of my endpoints because it will respond with a 401 before it gets to my route. In some cases, I would like to loosely secure an endpoint with just basic auth and nothing else or allow basic auth and oauth authorization. 

This change allows for users to implement their own basic auth endpoints if they see fit without compromising the req.username or req.clientId checks. 
