### PR TITLE
Add an allowPublicClients option to disable check for Authentication header

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ The `hooks` hash is the only required option, but the following are also availab
 * `tokenExpirationTime`: the value returned for the `expires_in` component of the response from the token endpoint.
   Note that this is *only* the value reported; you are responsible for keeping track of token expiration yourself and
   calling back with `false` from `authenticateToken` when the token expires. Defaults to `Infinity`.
+* `allowPublicClients`: allow requests to the `tokenEndpoint` that do not have client credentials. This option only
+  applies to ROPC flows. OAuth2 disallows use of public clients for the CC flow. The `validateClient` hook will still 
+  be called for all requests, but parameters may be `null`. Defaults to `false`.
 
 ## What Does That Look Like?
 

--- a/lib/cc/grantToken.js
+++ b/lib/cc/grantToken.js
@@ -5,7 +5,7 @@ var finishGrantingToken = require("../common/finishGrantingToken");
 var makeOAuthError = require("../common/makeOAuthError");
 
 module.exports = function grantToken(req, res, next, options) {
-    if (!validateGrantTokenRequest("client_credentials", req, next)) {
+    if (!validateGrantTokenRequest("client_credentials", false, req, next)) {
         return;
     }
 

--- a/lib/common/makeSetup.js
+++ b/lib/common/makeSetup.js
@@ -26,7 +26,8 @@ module.exports = function makeSetup(grantTypes, requiredHooks, grantToken) {
         options = _.defaults(options, {
             tokenEndpoint: "/token",
             wwwAuthenticateRealm: "Who goes there?",
-            tokenExpirationTime: Infinity
+            tokenExpirationTime: Infinity,
+            allowPublicClients: false
         });
 
         // Allow `tokenExpirationTime: Infinity` (like above), but translate it into `undefined` so that

--- a/lib/common/validateGrantTokenRequest.js
+++ b/lib/common/validateGrantTokenRequest.js
@@ -3,7 +3,7 @@
 var _ = require("underscore");
 var makeOAuthError = require("./makeOAuthError");
 
-module.exports = function validateGrantTokenRequest(grantType, req, next) {
+module.exports = function validateGrantTokenRequest(grantType, allowPublicClients, req, next) {
     function sendBadRequestError(type, description) {
         next(makeOAuthError("BadRequest", type, description));
     }
@@ -24,7 +24,7 @@ module.exports = function validateGrantTokenRequest(grantType, req, next) {
         return false;
     }
 
-    if (!req.authorization || !req.authorization.basic) {
+    if (!allowPublicClients && (!req.authorization || !req.authorization.basic)) {
         sendBadRequestError("invalid_request", "Must include a basic access authentication header.");
         return false;
     }

--- a/lib/ropc/grantToken.js
+++ b/lib/ropc/grantToken.js
@@ -11,7 +11,7 @@ module.exports = function grantToken(req, res, next, options) {
     }
 
 
-    if (!validateGrantTokenRequest("password", req, next)) {
+    if (!validateGrantTokenRequest("password", options.allowPublicClients, req, next)) {
         return;
     }
 
@@ -26,8 +26,12 @@ module.exports = function grantToken(req, res, next, options) {
         return next(makeOAuthError("BadRequest", "invalid_request", "Must specify password field."));
     }
 
-    var clientId = req.authorization.basic.username;
-    var clientSecret = req.authorization.basic.password;
+    var clientId = null;
+    var clientSecret = null;
+    if (req.authorization && req.authorization.basic) {
+        clientId = req.authorization.basic.username;
+        clientSecret = req.authorization.basic.password;
+    }
     var clientCredentials = { clientId: clientId, clientSecret: clientSecret };
 
     options.hooks.validateClient(clientCredentials, req, function (error, result) {


### PR DESCRIPTION
This pull request replaces #20.

After further reading reading of the spec, my understanding is client type is a property of a client and not the entire server. With #20, the entire server would be configured public or confidential.  With this PR a server could be configured to handle both public and confidential client types and act appropriately. 

The _allowPublicClients_ defaults to false to preserve compatibility with previous versions. 

If the option is false:
- any request without an authentication header will be rejected. 

If the option is true:
- requests without headers will be allowed, and clientId/clientSecret will be null
- requests with headers will be populated with the clientId and clientSecret

This approach also allows the potential for future support of the authorization_code grant type. Where you may receive a clientId but no secret: http://tools.ietf.org/html/rfc6749#section-3.2.1
