### PR TITLE
Responses to token granting should have JSON content type

### DIFF
--- a/lib/common/finishGrantingToken.js
+++ b/lib/common/finishGrantingToken.js
@@ -39,7 +39,9 @@ module.exports = function finishGrantingToken(allCredentials, token, options, re
             responseBody.scope = scopesGranted.join(" ");
         }
 
-        res.send(responseBody);
+        res.send(200, responseBody, {
+            'content-type': 'application/json'
+        });
         next();
     });
 };


### PR DESCRIPTION
In at least some cases, sending without declaring explicit content types can lead it to not be set when the response is sent.
