### PR TITLE
Update Tests to respect Mocha changes in beforeEach

### DIFF
--- a/examples/cc-with-scopes/server.js
+++ b/examples/cc-with-scopes/server.js
@@ -104,4 +104,9 @@ server.get(RESOURCES.SCOPED, function (req, res) {
     res.send(response);
 });
 
+server.post('/close', function(req, res){
+    res.send(200);
+    server.close();
+});
+
 server.listen(8080);

--- a/examples/cc-with-scopes/server.js
+++ b/examples/cc-with-scopes/server.js
@@ -11,8 +11,8 @@ var server = restify.createServer({
     name: "Example Restify-OAuth2 Client Credentials Server",
     version: require("../../package.json").version,
     formatters: {
-        "application/hal+json": function (req, res, body) {
-            return res.formatters["application/json"](req, res, body);
+        "application/hal+json": function (req, res, body, cb) {
+            return res.formatters["application/json"](req, res, body, cb);
         }
     }
 });

--- a/examples/cc/server.js
+++ b/examples/cc/server.js
@@ -78,4 +78,9 @@ server.get(RESOURCES.SECRET, function (req, res) {
     res.send(response);
 });
 
+server.post('/close', function(req, res){
+    res.send(200);
+    server.close();
+});
+
 server.listen(8080);

--- a/examples/cc/server.js
+++ b/examples/cc/server.js
@@ -11,8 +11,8 @@ var server = restify.createServer({
     name: "Example Restify-OAuth2 Client Credentials Server",
     version: require("../../package.json").version,
     formatters: {
-        "application/hal+json": function (req, res, body) {
-            return res.formatters["application/json"](req, res, body);
+        "application/hal+json": function (req, res, body, cb) {
+            return res.formatters["application/json"](req, res, body, cb);
         }
     }
 });

--- a/examples/ropc/server.js
+++ b/examples/ropc/server.js
@@ -78,4 +78,9 @@ server.get(RESOURCES.SECRET, function (req, res) {
     res.send(response);
 });
 
+server.post('/close', function(req, res){
+    res.send(200);
+    server.close();
+});
+
 server.listen(8080);

--- a/examples/ropc/server.js
+++ b/examples/ropc/server.js
@@ -11,8 +11,8 @@ var server = restify.createServer({
     name: "Example Restify-OAuth2 Resource Owner Password Credentials Server",
     version: require("../../package.json").version,
     formatters: {
-        "application/hal+json": function (req, res, body) {
-            return res.formatters["application/json"](req, res, body);
+        "application/hal+json": function (req, res, body, cb) {
+            return res.formatters["application/json"](req, res, body, cb);
         }
     }
 });

--- a/lib/ropc/grantToken.js
+++ b/lib/ropc/grantToken.js
@@ -40,7 +40,7 @@ module.exports = function grantToken(req, res, next, options) {
         }
 
         var allCredentials = { clientId: clientId, clientSecret: clientSecret, username: username, password: password };
-        options.hooks.grantUserToken(allCredentials, req, function (error, token) {
+        options.hooks.grantUserToken(allCredentials, req, res, function (error, token) {
             if (error) {
                 return next(error);
             }

--- a/test/cc-integration.coffee
+++ b/test/cc-integration.coffee
@@ -84,4 +84,8 @@ suite
     .get("/public")
         .expect(200)
     .next()
+    .discuss('test cleanup')
+        .post("/close")
+            .expect(200)
+                .next()
 .export(module)

--- a/test/cc-unit.coffee
+++ b/test/cc-unit.coffee
@@ -91,12 +91,13 @@ beforeEach ->
         }
     }
 
-    @doIt = => restifyOAuth2.cc(@server, options)
+    @doItBase = => restifyOAuth2.cc(@server, options)
+    @doIt = => @doItBase
     @doItWithScopes = => restifyOAuth2.cc(@server, optionsWithScope)
 
 describe "Client Credentials flow", ->
     it "should set up the token endpoint", ->
-        @doIt()
+        @doItBase()
 
         @server.post.should.have.been.calledWith(tokenEndpoint)
 
@@ -106,7 +107,7 @@ describe "Client Credentials flow", ->
             @req.path = => tokenEndpoint
             @res.nextSpy = @tokenNext
 
-            baseDoIt = @doIt
+            baseDoIt = @doItBase
             @doIt = =>
                 baseDoIt()
                 @postToTokenEndpoint()
@@ -347,7 +348,7 @@ describe "Client Credentials flow", ->
                 @req.authorization = { scheme: "Bearer", credentials: @token }
 
             it "should pause the request and authenticate the token", ->
-                @doIt()
+                @doItBase()
 
                 @req.pause.should.have.been.called
                 @authenticateToken.should.have.been.calledWith(@token, @req)
@@ -356,7 +357,7 @@ describe "Client Credentials flow", ->
                 beforeEach -> @authenticateToken.yields(null, true)
 
                 it "should resume the request and call `next`", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @pluginNext.should.have.been.calledWithExactly()
@@ -365,7 +366,7 @@ describe "Client Credentials flow", ->
                 beforeEach -> @authenticateToken.yields(null, false)
 
                 it "should resume the request and send a 401 response, along with WWW-Authenticate and Link headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @res.should.be.unauthorized(
@@ -378,7 +379,7 @@ describe "Client Credentials flow", ->
                     @authenticateToken.yields(new restify.UnauthorizedError(@errorMessage))
 
                 it "should resume the request and send the error, along with WWW-Authenticate and Link headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @res.should.be.unauthorized(@errorMessage)
@@ -389,7 +390,7 @@ describe "Client Credentials flow", ->
                     @authenticateToken.yields(@error)
 
                 it "should resume the request and send the error, but no headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @pluginNext.should.have.been.calledWith(@error)
@@ -399,7 +400,7 @@ describe "Client Credentials flow", ->
             beforeEach -> @req.authorization = {}
 
             it "should not set `req.clientId`, and simply call `next`", ->
-                @doIt()
+                @doItBase()
 
                 should.not.exist(@req.clientId)
                 @pluginNext.should.have.been.calledWithExactly()
@@ -412,7 +413,7 @@ describe "Client Credentials flow", ->
                     basic: { username: "aaa", password: "bbb" }
 
             it "should send a 400 response with WWW-Authenticate and Link headers", ->
-                @doIt()
+                @doItBase()
 
                 @res.should.be.bad("Bearer token required. Follow the oauth2-token link to get one!")
 
@@ -423,7 +424,7 @@ describe "Client Credentials flow", ->
                     credentials: ""
 
             it "should send a 400 response with WWW-Authenticate and Link headers", ->
-                @doIt()
+                @doItBase()
 
                 @res.should.be.bad("Bearer token required. Follow the oauth2-token link to get one!")
 
@@ -431,7 +432,7 @@ describe "Client Credentials flow", ->
         beforeEach ->
             @req.path = => "/other-resource"
             @res.nextSpy = @pluginNext
-            @doIt()
+            @doItBase()
 
         describe "with no arguments", ->
             beforeEach -> @res.sendUnauthenticated()
@@ -455,7 +456,7 @@ describe "Client Credentials flow", ->
         beforeEach ->
             @req.path = => "/other-resource"
             @res.nextSpy = @pluginNext
-            @doIt()
+            @doItBase()
 
         describe "with no arguments", ->
             beforeEach -> @res.sendUnauthorized()

--- a/test/cc-with-scopes-integration.coffee
+++ b/test/cc-with-scopes-integration.coffee
@@ -145,4 +145,8 @@ suite
             .expect(200)
         .next()
     .undiscuss()
+    .discuss('test cleanup')
+        .post("/close")
+            .expect(200)
+                .next()
 .export(module)

--- a/test/ropc-integration.coffee
+++ b/test/ropc-integration.coffee
@@ -94,4 +94,8 @@ suite
     .get("/public")
         .expect(200)
     .next()
+    .discuss('test cleanup')
+        .post("/close")
+            .expect(200)
+    .next()
 .export(module)

--- a/test/ropc-unit.coffee
+++ b/test/ropc-unit.coffee
@@ -94,12 +94,13 @@ beforeEach ->
         }
     }
 
-    @doIt = => restifyOAuth2.ropc(@server, options)
+    @doItBase = => restifyOAuth2.ropc(@server, options)
+    @doIt = => @doItBase
     @doItWithScopes = => restifyOAuth2.ropc(@server, optionsWithScope)
 
 describe "Resource Owner Password Credentials flow", ->
     it "should set up the token endpoint", ->
-        @doIt()
+        @doItBase()
 
         @server.post.should.have.been.calledWith(tokenEndpoint)
 
@@ -109,7 +110,7 @@ describe "Resource Owner Password Credentials flow", ->
             @req.path = => tokenEndpoint
             @res.nextSpy = @tokenNext
 
-            baseDoIt = @doIt
+            baseDoIt = @doItBase
             @doIt = =>
                 baseDoIt()
                 @postToTokenEndpoint()
@@ -441,7 +442,7 @@ describe "Resource Owner Password Credentials flow", ->
                 @req.authorization = { scheme: "Bearer", credentials: @token }
 
             it "should pause the request and authenticate the token", ->
-                @doIt()
+                @doItBase()
 
                 @req.pause.should.have.been.called
                 @authenticateToken.should.have.been.calledWith(@token, @req)
@@ -450,7 +451,7 @@ describe "Resource Owner Password Credentials flow", ->
                 beforeEach -> @authenticateToken.yields(null, true)
 
                 it "should resume the request and call `next`", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @pluginNext.should.have.been.calledWithExactly()
@@ -459,7 +460,7 @@ describe "Resource Owner Password Credentials flow", ->
                 beforeEach -> @authenticateToken.yields(null, false)
 
                 it "should resume the request and send a 401 response, along with WWW-Authenticate and Link headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @res.should.be.unauthorized(
@@ -472,7 +473,7 @@ describe "Resource Owner Password Credentials flow", ->
                     @authenticateToken.yields(new restify.UnauthorizedError(@errorMessage))
 
                 it "should resume the request and send the error, along with WWW-Authenticate and Link headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @res.should.be.unauthorized(@errorMessage)
@@ -483,7 +484,7 @@ describe "Resource Owner Password Credentials flow", ->
                     @authenticateToken.yields(@error)
 
                 it "should resume the request and send the error, but no headers", ->
-                    @doIt()
+                    @doItBase()
 
                     @req.resume.should.have.been.called
                     @pluginNext.should.have.been.calledWith(@error)
@@ -493,7 +494,7 @@ describe "Resource Owner Password Credentials flow", ->
             beforeEach -> @req.authorization = {}
 
             it "should remove `req.username`, and simply call `next`", ->
-                @doIt()
+                @doItBase()
 
                 should.not.exist(@req.username)
                 @pluginNext.should.have.been.calledWithExactly()
@@ -506,7 +507,7 @@ describe "Resource Owner Password Credentials flow", ->
                     basic: { username: "aaa", password: "bbb" }
 
             it "should send a 400 response with WWW-Authenticate and Link headers", ->
-                @doIt()
+                @doItBase()
 
                 @res.should.be.bad("Bearer token required. Follow the oauth2-token link to get one!")
 
@@ -517,7 +518,7 @@ describe "Resource Owner Password Credentials flow", ->
                     credentials: ""
 
             it "should send a 400 response with WWW-Authenticate and Link headers", ->
-                @doIt()
+                @doItBase()
 
                 @res.should.be.bad("Bearer token required. Follow the oauth2-token link to get one!")
 
@@ -525,7 +526,7 @@ describe "Resource Owner Password Credentials flow", ->
         beforeEach ->
             @req.path = => "/other-resource"
             @res.nextSpy = @pluginNext
-            @doIt()
+            @doItBase()
 
         describe "with no arguments", ->
             beforeEach -> @res.sendUnauthenticated()
@@ -549,7 +550,7 @@ describe "Resource Owner Password Credentials flow", ->
         beforeEach ->
             @req.path = => "/other-resource"
             @res.nextSpy = @pluginNext
-            @doIt()
+            @doItBase()
 
         describe "with no arguments", ->
             beforeEach -> @res.sendUnauthorized()


### PR DESCRIPTION
Fixed tests broken in recent version updates.

Sorry about the naming, couldn't quite think of anything better.

Resolution dealt with changes in Mocha's beforeEach function being run on every child causing the doIt function to recurse on itself. Also updated examples to match new Restify formatter.