### PR TITLE
restify-errors

### DIFF
--- a/lib/common/makeErrorSenders.js
+++ b/lib/common/makeErrorSenders.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var restify = require("restify");
+var restify = require("restify-errors");
 
 var statusCodesToErrorCodes = {
     400: "invalid_request",

--- a/lib/common/makeOAuthError.js
+++ b/lib/common/makeOAuthError.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var restify = require("restify");
+var restify = require("restify-errors");
 
 module.exports = function makeOAuthError(errorClass, errorType, errorDescription) {
     var body = { error: errorType, error_description: errorDescription };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "underscore": "1.x"
   },
   "peerDependencies": {
-    "restify": "4.x"
+    "restify": "4.x",
+    "restify-errors": "4.x"
   },
   "devDependencies": {
     "api-easy": "^0.4.0",


### PR DESCRIPTION
errors doesn't really exist natively in restify in the same way as before, thus switch to restify-errors for errors gives better errors