### PR TITLE
Migrating from Restify 4.x to Restify 5.x. Closes #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ var restify = require("restify");
 var restifyOAuth2 = require("restify-oauth2");
 
 var server = restify.createServer({ name: "My cool server", version: "1.0.0" });
-server.use(restify.authorizationParser());
-server.use(restify.bodyParser({ mapParams: false }));
+server.use(restify.plugins.authorizationParser());
+server.use(restify.plugins.bodyParser({ mapParams: false }));
 
 restifyOAuth2.cc(server, options);
 // or

--- a/examples/cc-with-scopes/server.js
+++ b/examples/cc-with-scopes/server.js
@@ -25,8 +25,8 @@ var RESOURCES = Object.freeze({
     SCOPED: "/scoped"
 });
 
-server.use(restify.authorizationParser());
-server.use(restify.bodyParser({ mapParams: false }));
+server.use(restify.plugins.authorizationParser());
+server.use(restify.plugins.bodyParser({ mapParams: false }));
 restifyOAuth2.cc(server, { tokenEndpoint: RESOURCES.TOKEN, hooks: hooks });
 
 

--- a/examples/cc/server.js
+++ b/examples/cc/server.js
@@ -24,8 +24,8 @@ var RESOURCES = Object.freeze({
     SECRET: "/secret"
 });
 
-server.use(restify.authorizationParser());
-server.use(restify.bodyParser({ mapParams: false }));
+server.use(restify.plugins.authorizationParser());
+server.use(restify.plugins.bodyParser({ mapParams: false }));
 restifyOAuth2.cc(server, { tokenEndpoint: RESOURCES.TOKEN, hooks: hooks });
 
 

--- a/examples/ropc/server.js
+++ b/examples/ropc/server.js
@@ -24,8 +24,8 @@ var RESOURCES = Object.freeze({
     SECRET: "/secret"
 });
 
-server.use(restify.authorizationParser());
-server.use(restify.bodyParser({ mapParams: false }));
+server.use(restify.plugins.authorizationParser());
+server.use(restify.plugins.bodyParser({ mapParams: false }));
 restifyOAuth2.ropc(server, { tokenEndpoint: RESOURCES.TOKEN, hooks: hooks });
 
 

--- a/lib/cc/grantToken.js
+++ b/lib/cc/grantToken.js
@@ -20,7 +20,7 @@ module.exports = function grantToken(req, res, next, options) {
 
         if (!token) {
             res.header("WWW-Authenticate", "Basic realm=\"Client ID and secret did not authenticate.\"");
-            return next(makeOAuthError("Unauthorized", "invalid_client", "Client ID and secret did not authenticate."));
+            return next(makeOAuthError("InvalidClient", "Client ID and secret did not authenticate."));
         }
 
         var allCredentials = { clientId: clientId, clientSecret: clientSecret, token: token };

--- a/lib/common/finishGrantingToken.js
+++ b/lib/common/finishGrantingToken.js
@@ -9,7 +9,7 @@ module.exports = function finishGrantingToken(allCredentials, token, options, re
     if (_.has(req.body, "scope")) {
         if (typeof req.body.scope !== "string") {
             var message = "The scope value must be a space-delimited string, if present.";
-            return next(makeOAuthError("BadRequest", "invalid_scope", message));
+            return next(makeOAuthError("InvalidScope", message));
         }
         shouldIncludeScopeInResponse = true;
         scopesRequested = req.body.scope.split(" ");
@@ -23,7 +23,7 @@ module.exports = function finishGrantingToken(allCredentials, token, options, re
         if (!scopesGranted) {
             var message = "The requested scopes are invalid, unknown, or exceed the set of scopes appropriate for " +
                           "these credentials.";
-            return next(makeOAuthError("BadRequest", "invalid_scope", message));
+            return next(makeOAuthError("InvalidScope", message));
         }
 
         if (scopesGranted === true) {

--- a/lib/common/makeErrorSenders.js
+++ b/lib/common/makeErrorSenders.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var restify = require("restify");
+var errs = require("restify-errors");
 
 var statusCodesToErrorCodes = {
     400: "invalid_request",
@@ -55,7 +56,7 @@ module.exports = function makeErrorSenders(grantTypes) {
                 message = "Bearer token required. Follow the oauth2-token link to get one!";
             }
 
-            sendWithHeaders(res, next, options, new restify.BadRequestError(message));
+            sendWithHeaders(res, next, options, new errs.BadRequestError(message));
         },
 
         authenticationRequired: function (res, next, options, message) {
@@ -63,7 +64,7 @@ module.exports = function makeErrorSenders(grantTypes) {
                 message = "Authentication via bearer token required. Follow the oauth2-token link to get one!";
             }
 
-            sendAuthenticationRequired(res, next, options, new restify.UnauthorizedError(message));
+            sendAuthenticationRequired(res, next, options, new errs.UnauthorizedError(message));
         },
 
         insufficientAuthorization: function (res, next, options, message) {
@@ -72,7 +73,7 @@ module.exports = function makeErrorSenders(grantTypes) {
                           "authorization!";
             }
 
-            sendInsufficientAuthorization(res, next, options, new restify.ForbiddenError(message));
+            sendInsufficientAuthorization(res, next, options, new errs.ForbiddenError(message));
         },
 
         tokenInvalid: function (res, next, options, message) {
@@ -80,7 +81,7 @@ module.exports = function makeErrorSenders(grantTypes) {
                 message = "Bearer token invalid. Follow the oauth2-token link to get a valid one!";
             }
 
-            sendWithHeaders(res, next, options, new restify.UnauthorizedError(message));
+            sendWithHeaders(res, next, options, new errs.UnauthorizedError(message));
         }
     };
 };

--- a/lib/common/makeOAuthError.js
+++ b/lib/common/makeOAuthError.js
@@ -1,8 +1,28 @@
 "use strict";
 
 var restify = require("restify");
+var errs = require("restify-errors");
 
-module.exports = function makeOAuthError(errorClass, errorType, errorDescription) {
-    var body = { error: errorType, error_description: errorDescription };
-    return new restify[errorClass + "Error"]({ message: errorDescription, body: body });
+errs.makeConstructor('InvalidRequestError', {
+    statusCode: 400
+});
+
+errs.makeConstructor('InvalidScopeError', {
+    statusCode: 400
+});
+
+errs.makeConstructor('UnsupportedGrantTypeError', {
+    statusCode: 400
+});
+
+errs.makeConstructor('InvalidClientError', {
+    statusCode: 401
+});
+
+errs.makeConstructor('InvalidGrantError', {
+    statusCode: 401
+});
+
+module.exports = function makeOAuthError(errorClass, errorDescription) {
+    return new errs[errorClass + "Error"]({ message: errorDescription });
 };

--- a/lib/common/validateGrantTokenRequest.js
+++ b/lib/common/validateGrantTokenRequest.js
@@ -5,33 +5,32 @@ var makeOAuthError = require("./makeOAuthError");
 
 module.exports = function validateGrantTokenRequest(grantType, req, next) {
     function sendBadRequestError(type, description) {
-        next(makeOAuthError("BadRequest", type, description));
+      next(makeOAuthError(type, description));
     }
 
-
     if (!req.body || typeof req.body !== "object") {
-        sendBadRequestError("invalid_request", "Must supply a body.");
+        sendBadRequestError("InvalidRequest", "Must supply a body.");
         return false;
     }
 
     if (!_.has(req.body, "grant_type")) {
-        sendBadRequestError("invalid_request", "Must specify grant_type field.");
+        sendBadRequestError("InvalidRequest", "Must specify grant_type field.");
         return false;
     }
 
     if (req.body.grant_type !== grantType) {
-        sendBadRequestError("unsupported_grant_type", "Only grant_type=" + grantType + " is supported.");
+        sendBadRequestError("UnsupportedGrantType", "Only grant_type=" + grantType + " is supported.");
         return false;
     }
 
     if (!req.authorization || !req.authorization.basic) {
-        sendBadRequestError("invalid_request", "Must include a basic access authentication header.");
+        sendBadRequestError("InvalidRequest", "Must include a basic access authentication header.");
         return false;
     }
 
     if (_.has(req.body, "scope")) {
         if (typeof req.body.scope !== "string") {
-            sendBadRequestError("invalid_request", "Must specify a space-delimited string for the scope field.");
+            sendBadRequestError("InvalidRequest", "Must specify a space-delimited string for the scope field.");
             return false;
         }
     }

--- a/lib/ropc/grantToken.js
+++ b/lib/ropc/grantToken.js
@@ -7,7 +7,7 @@ var makeOAuthError = require("../common/makeOAuthError");
 module.exports = function grantToken(req, res, next, options) {
     function sendUnauthorizedError(type, description) {
         res.header("WWW-Authenticate", "Basic realm=\"" + description + "\"");
-        next(makeOAuthError("Unauthorized", type, description));
+        next(makeOAuthError(type, description));
     }
 
 
@@ -19,11 +19,11 @@ module.exports = function grantToken(req, res, next, options) {
     var password = req.body.password;
 
     if (!username) {
-        return next(makeOAuthError("BadRequest", "invalid_request", "Must specify username field."));
+        return next(makeOAuthError("InvalidRequest", "Must specify username field."));
     }
 
     if (!password) {
-        return next(makeOAuthError("BadRequest", "invalid_request", "Must specify password field."));
+        return next(makeOAuthError("InvalidRequest", "Must specify password field."));
     }
 
     var clientId = req.authorization.basic.username;
@@ -36,7 +36,7 @@ module.exports = function grantToken(req, res, next, options) {
         }
 
         if (!result) {
-            return sendUnauthorizedError("invalid_client", "Client ID and secret did not validate.");
+            return sendUnauthorizedError("InvalidClient", "Client ID and secret did not validate.");
         }
 
         var allCredentials = { clientId: clientId, clientSecret: clientSecret, username: username, password: password };
@@ -46,7 +46,7 @@ module.exports = function grantToken(req, res, next, options) {
             }
 
             if (!token) {
-                return sendUnauthorizedError("invalid_grant", "Username and password did not authenticate.");
+                return sendUnauthorizedError("InvalidGrant", "Username and password did not authenticate.");
             }
 
             var allCredentials = {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "underscore": "1.x"
   },
   "peerDependencies": {
-    "restify": "4.x"
+    "restify": "5.x",
+    "restify-errors": "5.x"
   },
   "devDependencies": {
     "api-easy": "^0.4.0",
@@ -40,7 +41,8 @@
     "coffee-script": "^1.9.3",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
-    "restify": "^4.0",
+    "restify": "^5.0",
+    "restify-errors": "^5.0",
     "sinon": "^1.16.1",
     "sinon-chai": "^2.8.0",
     "vows": "^0.8.1"

--- a/test/cc-integration.coffee
+++ b/test/cc-integration.coffee
@@ -65,8 +65,8 @@ suite
             .setHeader("Content-Type", "application/json")
             .post({ grant_type: "client_credentials" })
                 .expect(401)
-                .expect("should respond with error: invalid_client", (err, res, body) ->
-                    JSON.parse(body).should.have.property("error", "invalid_client")
+                .expect("should respond with error: InvalidClient", (err, res, body) ->
+                    JSON.parse(body).should.have.property("code", "InvalidClient")
                 )
         .undiscuss()
     .unpath().next()

--- a/test/cc-unit.coffee
+++ b/test/cc-unit.coffee
@@ -5,6 +5,7 @@ sinon = require("sinon")
 should = require("chai").should()
 Assertion = require("chai").Assertion
 restify = require("restify")
+errs = require("restify-errors")
 restifyOAuth2 = require("..")
 
 tokenEndpoint = "/token-uri"
@@ -23,7 +24,7 @@ Assertion.addMethod("unauthorized", (message, options) ->
     @_obj.header.should.have.been.calledWith("WWW-Authenticate", expectedWwwAuthenticate)
     @_obj.header.should.have.been.calledWith("Link", expectedLink)
     spyToTest.should.have.been.calledOnce
-    spyToTest.should.have.been.calledWith(sinon.match.instanceOf(restify.UnauthorizedError))
+    spyToTest.should.have.been.calledWith(sinon.match.instanceOf(errs.UnauthorizedError))
     spyToTest.should.have.been.calledWith(sinon.match.has("message", sinon.match(message)))
 )
 
@@ -32,7 +33,7 @@ Assertion.addMethod("unauthenticated", (message) ->
 
     @_obj.header.should.have.been.calledWith("Link", expectedLink)
     @_obj.send.should.have.been.calledOnce
-    @_obj.send.should.have.been.calledWith(sinon.match.instanceOf(restify.ForbiddenError))
+    @_obj.send.should.have.been.calledWith(sinon.match.instanceOf(errs.ForbiddenError))
     @_obj.send.should.have.been.calledWith(sinon.match.has("message", sinon.match(message)))
 )
 
@@ -44,16 +45,14 @@ Assertion.addMethod("bad", (message) ->
     @_obj.header.should.have.been.calledWith("WWW-Authenticate", expectedWwwAuthenticate)
     @_obj.header.should.have.been.calledWith("Link", expectedLink)
     @_obj.nextSpy.should.have.been.calledOnce
-    @_obj.nextSpy.should.have.been.calledWith(sinon.match.instanceOf(restify.BadRequestError))
+    @_obj.nextSpy.should.have.been.calledWith(sinon.match.instanceOf(errs.BadRequestError))
     @_obj.nextSpy.should.have.been.calledWith(sinon.match.has("message", sinon.match(message)))
 )
 
-Assertion.addMethod("oauthError", (errorClass, errorType, errorDescription) ->
-    desiredBody = { error: errorType, error_description: errorDescription }
+Assertion.addMethod("oauthError", (errorClass, errorDescription) ->
     @_obj.nextSpy.should.have.been.calledOnce
-    @_obj.nextSpy.should.have.been.calledWith(sinon.match.instanceOf(restify[errorClass + "Error"]))
+    @_obj.nextSpy.should.have.been.calledWith(sinon.match.instanceOf(errs[errorClass + "Error"]))
     @_obj.nextSpy.should.have.been.calledWith(sinon.match.has("message", errorDescription))
-    @_obj.nextSpy.should.have.been.calledWith(sinon.match.has("body", desiredBody))
 )
 
 beforeEach ->
@@ -200,7 +199,7 @@ describe "Client Credentials flow", ->
 
                                     message = "The requested scopes are invalid, unknown, or exceed the set of " +
                                               "scopes appropriate for these credentials."
-                                    @res.should.be.an.oauthError("BadRequest", "invalid_scope", message)
+                                    @res.should.be.an.oauthError("InvalidScope", message)
 
                             describe "when `grantScopes` calls back with an error", ->
                                 beforeEach ->
@@ -235,7 +234,7 @@ describe "Client Credentials flow", ->
                         it "should send a 401 response with error_type=invalid_client", ->
                             @doIt()
 
-                            @res.should.be.an.oauthError("Unauthorized", "invalid_client",
+                            @res.should.be.an.oauthError("InvalidClient",
                                                          "Client ID and secret did not authenticate.")
 
                     describe "when `grantClientToken` calls back with `null`", ->
@@ -244,7 +243,7 @@ describe "Client Credentials flow", ->
                         it "should send a 401 response with error_type=invalid_client", ->
                             @doIt()
 
-                            @res.should.be.an.oauthError("Unauthorized", "invalid_client",
+                            @res.should.be.an.oauthError("InvalidClient",
                                                          "Client ID and secret did not authenticate.")
 
                     describe "when `grantClientToken` calls back with an error", ->
@@ -261,7 +260,7 @@ describe "Client Credentials flow", ->
                     it "should send a 400 response with error_type=invalid_request", ->
                         @doIt()
 
-                        @res.should.be.an.oauthError("BadRequest", "invalid_request",
+                        @res.should.be.an.oauthError("InvalidRequest",
                                                      "Must include a basic access authentication header.")
 
                     it "should not call the `grantClientToken` hook", ->
@@ -278,7 +277,7 @@ describe "Client Credentials flow", ->
                     it "should send a 400 response with error_type=invalid_request", ->
                         @doIt()
 
-                        @res.should.be.an.oauthError("BadRequest", "invalid_request",
+                        @res.should.be.an.oauthError("InvalidRequest",
                                                      "Must include a basic access authentication header.")
 
                     it "should not call the `grantClientToken` hook", ->
@@ -292,7 +291,7 @@ describe "Client Credentials flow", ->
                 it "should send a 400 response with error_type=unsupported_grant_type", ->
                     @doIt()
 
-                    @res.should.be.an.oauthError("BadRequest", "unsupported_grant_type",
+                    @res.should.be.an.oauthError("UnsupportedGrantType",
                                                  "Only grant_type=client_credentials is supported.")
 
                 it "should not call the `grantClientToken` hook", ->
@@ -304,7 +303,7 @@ describe "Client Credentials flow", ->
                 it "should send a 400 response with error_type=invalid_request", ->
                     @doIt()
 
-                    @res.should.be.an.oauthError("BadRequest", "invalid_request", "Must specify grant_type field.")
+                    @res.should.be.an.oauthError("InvalidRequest", "Must specify grant_type field.")
 
                 it "should not call the `grantClientToken` hook", ->
                     @doIt()
@@ -317,7 +316,7 @@ describe "Client Credentials flow", ->
             it "should send a 400 response with error_type=invalid_request", ->
                 @doIt()
 
-                @res.should.be.an.oauthError("BadRequest", "invalid_request", "Must supply a body.")
+                @res.should.be.an.oauthError("InvalidRequest", "Must supply a body.")
 
             it "should not call the `grantClientToken` hook", ->
                 @doIt()
@@ -330,7 +329,7 @@ describe "Client Credentials flow", ->
             it "should send a 400 response with error_type=invalid_request", ->
                 @doIt()
 
-                @res.should.be.an.oauthError("BadRequest", "invalid_request", "Must supply a body.")
+                @res.should.be.an.oauthError("InvalidRequest", "Must supply a body.")
 
             it "should not call the `grantClientToken` hook", ->
                 @doIt()
@@ -376,7 +375,7 @@ describe "Client Credentials flow", ->
             describe "when the `authenticateToken` calls back with a 401 error", ->
                 beforeEach ->
                     @errorMessage = "The authentication failed for some reason."
-                    @authenticateToken.yields(new restify.UnauthorizedError(@errorMessage))
+                    @authenticateToken.yields(new errs.UnauthorizedError(@errorMessage))
 
                 it "should resume the request and send the error, along with WWW-Authenticate and Link headers", ->
                     @doItBase()
@@ -386,7 +385,7 @@ describe "Client Credentials flow", ->
 
             describe "when the `authenticateToken` calls back with a non-401 error", ->
                 beforeEach ->
-                    @error = new restify.ForbiddenError("The authentication succeeded but this resource is forbidden.")
+                    @error = new errs.ForbiddenError("The authentication succeeded but this resource is forbidden.")
                     @authenticateToken.yields(@error)
 
                 it "should resume the request and send the error, but no headers", ->

--- a/test/cc-with-scopes-integration.coffee
+++ b/test/cc-with-scopes-integration.coffee
@@ -84,8 +84,8 @@ suite
             .setHeader("Content-Type", "application/json")
             .post({ grant_type: "client_credentials" })
                 .expect(401)
-                .expect("should respond with error: invalid_client", (err, res, body) ->
-                    JSON.parse(body).should.have.property("error", "invalid_client")
+                .expect("should respond with error: InvalidClient", (err, res, body) ->
+                    JSON.parse(body).should.have.property("code", "InvalidClient")
                 )
         .undiscuss()
     .unpath().next()

--- a/test/ropc-integration.coffee
+++ b/test/ropc-integration.coffee
@@ -65,8 +65,8 @@ suite
             .discuss("but invalid user credentials")
                 .post({ grant_type: "password", username: "blargh", password: "asdf" })
                     .expect(401)
-                    .expect("should respond with error: invalid_grant", (err, res, body) ->
-                        JSON.parse(body).should.have.property("error", "invalid_grant")
+                    .expect("should respond with error: InvalidGrant", (err, res, body) ->
+                        JSON.parse(body).should.have.property("code", "InvalidGrant")
                     )
             .undiscuss()
         .undiscuss()
@@ -75,8 +75,8 @@ suite
             .setHeader("Content-Type", "application/json")
             .post({ grant_type: "password", username, password })
                 .expect(401)
-                .expect("should respond with error: invalid_client", (err, res, body) ->
-                    JSON.parse(body).should.have.property("error", "invalid_client")
+                .expect("should respond with error: InvalidClient", (err, res, body) ->
+                    JSON.parse(body).should.have.property("code", "InvalidClient")
                 )
         .undiscuss()
     .unpath().next()


### PR DESCRIPTION
See #47.

Please review and let me know if this works for you. Since Restify 5.x removed the `restify.errors` property, I had to use the `restify-errors` package. 

The most important change is that restify-errors don't allow the customization of the `body`, but it does allow the creation of new errors using the `makeConstructor` function. So the JSON output will change a little bit from { error: ..., errorDescription: ...}  to { code: ..., message: ... }. Does that comply with the specification?